### PR TITLE
Add manifest file for deploying to PaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# GOV.UK Prototype kit · [![Greenkeeper badge](https://badges.greenkeeper.io/alphagov/govuk_prototype_kit.svg)](https://greenkeeper.io/)
+# Digital Marketplace Capture Spend Data Task List Prototype
+
+This has a `manifest.yml` file ready to be [deployed to the PaaS](https://alphagov.github.io/digitalmarketplace-manual/paas.html?highlight=paas). If it is going onto the Digital Marketplace org then use the `labs` space. Remember to set the basic auth `USERNAME` and `PASSWORD` envars on the app.
+
+Once deployed it will be available at:
+
+http://digitalmarketplace-capture-spend-data-task-list.cloudapps.digital
+
+
+## GOV.UK Prototype kit · [![Greenkeeper badge](https://badges.greenkeeper.io/alphagov/govuk_prototype_kit.svg)](https://greenkeeper.io/)
 
 Go to the [GOV.UK Prototype Kit site](https://govuk-prototype-kit.herokuapp.com/docs) to download the latest version and read the documentation.
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,5 @@
+---
+applications:
+- name: digitalmarketplace-capture-spend-data-task-list
+  memory: 256M
+  buildpack: nodejs_buildpack

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "6.3.0",
   "private": true,
   "engines": {
-    "node": ">=6.11.1 <7.0"
+    "node": "8.11.2"
   },
   "scripts": {
     "start": "node start.js",


### PR DESCRIPTION
- Add manifest file for deploying to PaaS
- Bump node to version available in PaaS Node buildpacks (as of June 2018)